### PR TITLE
fix: add node and mocha to tsconfig types field

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,7 +42,7 @@
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": [],                           /* Type declaration files to be included in compilation. */
+    "types": ["node", "mocha"],               /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */


### PR DESCRIPTION
## Problem

TypeScript 6 changed how `@types/*` packages are included — it no longer auto-includes them globally when the `types` field is absent from `tsconfig.json`. This broke the CI build on all platforms with 60 errors like:

- `Cannot find name 'Buffer'` / `'process'` / `'fs'` / `'path'` / `'os'`
- `Cannot find namespace 'NodeJS'`
- `Cannot find name 'describe'` / `'it'` / `'before'` / `'assert'`

These were surfaced by PR #310 (which triggered fresh CI runs) but the root cause exists on `main` too.

## Fix

Uncomment and explicitly set the `types` field in `tsconfig.json`:

```json
"types": ["node", "mocha"]
```

Both packages are already in `devDependencies` — they just needed to be explicitly referenced.

## Verification

- `npm run build` → ✅ 0 errors (was 60)
- `npm test` → ✅ 17/17 tests passing