### PR TITLE
chore: update to Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: 22
+        node-version: 24
 
     - name: 'Validate build'
       run: |

--- a/action.yml
+++ b/action.yml
@@ -6,5 +6,5 @@ inputs:
     description: 'comma separated list of XML/JSON/YAML files in which tokens are to be substituted. Files names must be specified relative to the folder-path.'
     required: true
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'lib/variableSubstitution.js'

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
   ],
   "author": "Sumiran Aggarwal <suaggar@microsoft.com>",
   "license": "MIT",
+  "engines": {
+    "node": ">=24"
+  },
   "bugs": {
     "url": "https://github.com/SumiranAgg/filetransform/issues"
   },


### PR DESCRIPTION
Updates the action and CI workflow to use Node.js 24.

## Changes
- \ction.yml\: \
ode20\ → \
ode24\  
- \.github/workflows/ci.yml\: \
ode-version: 22\ → \
ode-version: 24\
- \package.json\: adds \ngines: { node: '>=24' }\

All 17 tests pass locally.